### PR TITLE
Fix onDownload not reading variables from msg and flow

### DIFF
--- a/nbrowser/nbrowser.js
+++ b/nbrowser/nbrowser.js
@@ -312,7 +312,7 @@ module.exports = function(RED) {
                           case 'onDownload':
                               return nbrowser.once('download', function(state, downloadItem){
                                   if(state == 'started') {
-                                      node.file = r[0].value;
+                                      node.file = getTypeInputValue(r[0].type, r[0].value);
                                       nbrowser.emit('download', node.file, downloadItem);
                                       nbrowser.downloadManager().waitDownloadsComplete();
                                   }


### PR DESCRIPTION
While trying to download a file using nbrowser i realized that the name of the file was always the String literal set as a value in the action configuration, regardless of the "msg", "flow" type. I reused what i think it should have been there from the very beggining.